### PR TITLE
fix for 'clicking on overlay does nothing'

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -8,8 +8,12 @@ function createElement (text, level) {
   return element
 }
 
+
 export default function (editor, marker, text, level) {
   let item = createElement(text, level)
+  item.addEventListener("click", function(){
+    editor.setCursorScreenPosition(marker.getStartScreenPosition());
+  }, false);
   return editor.decorateMarker(marker, {
     class: 'rainbow',
     item,


### PR DESCRIPTION
I'm assuming that this is what the readme text means when it says 
"Clicking on overlay does nothing".

I assume that clicking on a marker (i.e. a colored paren) should move the cursor there.
This commit fix this so that it does move the cursor there.

My only concern is that there are quite a few listeners added in to the mix. 
Basically one for each marker.

Don't merge this in yet please. Just let me know if this is the correct behaviour.